### PR TITLE
Add FakeUserAgentError

### DIFF
--- a/proxypool/utils.py
+++ b/proxypool/utils.py
@@ -2,11 +2,14 @@ import requests
 import asyncio
 import aiohttp
 from requests.exceptions import ConnectionError
-from fake_useragent import UserAgent
+from fake_useragent import UserAgent,FakeUserAgentError
 import random
 
 def get_page(url, options={}):
-    ua = UserAgent()
+    try:
+        ua = UserAgent()
+    except FakeUserAgentError:
+        pass
     base_headers = {
         'User-Agent':  ua.random,
         'Accept-Encoding': 'gzip, deflate, sdch',


### PR DESCRIPTION
Sometimes, useragentstring.com or w3schools.com changes their html, or down, in such case fake-useragent uses hosted cache server heroku.com fallback.
In very rare case, if hosted cache server and sources will be unavailable fake-useragent wont be able to download data.

#### Traceback (most recent call last):
####   ...
#### fake_useragent.errors.FakeUserAgentError

##### You can catch it via
```python
from fake_useragent import FakeUserAgentError
try:
    ua = UserAgent()
except FakeUserAgentError:
    pass
```